### PR TITLE
fix `write_solution` for vector fields

### DIFF
--- a/src/NODDofHandler.jl
+++ b/src/NODDofHandler.jl
@@ -903,7 +903,7 @@ function Ferrite._evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, dh::NODDof
         u::Vector{T}, cv::CellValues, drange::UnitRange, ::Type{RT}) where {T, RT}
     ue = zeros(T, length(drange))
     # TODO: Remove this hack when embedding works...
-    if RT <: Vec && cv isa CellValues{<:ScalarInterpolation}
+    if RT <: Vec && Ferrite.function_interpolation(cv) isa Ferrite.ScalarInterpolation
         uer = reinterpret(RT, ue)
     else
         uer = ue


### PR DESCRIPTION
This PR fixes the `write_solution` crashes for vector-valued fields (e.g. 3D displacement `Lagrange{RefHexahedron,1}()^3`) with the error: `number of base functions (8) does not match length of vector (24)`

The issue is that   `_evaluate_at_grid_nodes!` contains a type check to decide whether to reinterpret the local dof vector as a `Vec`:

```julia
function Ferrite._evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, dh::NODDofHandler, sdh::SubDofHandler,
        u::Vector{T}, cv::CellValues, drange::UnitRange, ::Type{RT}) where {T, RT}
        ...
        if RT <: Vec && cv isa CellValues{<:ScalarInterpolation}
            uer = reinterpret(RT, ue)
        else
        ...
end
```
However, `CellValues` is parameterised as `CellValues{FV<:FunctionValues, GM, QR, detT}` without the interpolation is no longer in the type parameter. The `isa` check therefore always returns `false` for vector fields, so `uer = ue` (length 24) is passed to `function_value(cv, qp, uer)` which expects length 8.

The fix is very simple and only requires changing the check to `RT <: Vec && Ferrite.function_interpolation(cv) isa Ferrite.ScalarInterpolation`.

This PR was co-authored by Claude Code v2.1.146 (Sonnet 4.6).

PS. I'm happy to add my example with vector field to the docs if you want? (Neohookean cube under prescribed extension rotation with NR solver.)